### PR TITLE
chore: Bump cross-spawn version

### DIFF
--- a/qg-api-service/package-lock.json
+++ b/qg-api-service/package-lock.json
@@ -24,6 +24,7 @@
       }
     },
     "api-commons-lib": {
+      "name": "@B-S-F/api-commons-lib",
       "version": "0.8.0",
       "dependencies": {
         "@nestjs/common": "^10.4.4",
@@ -264,6 +265,7 @@
       }
     },
     "api-keycloak-auth-lib": {
+      "name": "@B-S-F/api-keycloak-auth-lib",
       "version": "0.10.0",
       "dependencies": {
         "@nestjs/common": "^10.4.4",
@@ -7374,9 +7376,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
Updates cross-spawn from 7.0.3 to 7.0.5 to resolve https://github.com/B-S-F/yaku/security/dependabot/14