### PR TITLE
feat: Report SharePoint connection errors as exceptions

### DIFF
--- a/yaku-apps-python/apps/pdf-signature-evaluator/BUILD
+++ b/yaku-apps-python/apps/pdf-signature-evaluator/BUILD
@@ -2,7 +2,3 @@ pex_binary(
     name="pdf-signature-evaluator",
     entry_point="yaku.pdf_signature_evaluator.cli",
 )
-
-poetry_requirements(
-    name="poetry",
-)

--- a/yaku-apps-python/apps/pdf-signature-evaluator/pyproject.toml
+++ b/yaku-apps-python/apps/pdf-signature-evaluator/pyproject.toml
@@ -1,4 +1,2 @@
-[tool.poetry.dependencies]
-
 [tool.coverage.run]
 omit = ["tests"]

--- a/yaku-apps-python/apps/pdf-signature-evaluator/tests/BUILD
+++ b/yaku-apps-python/apps/pdf-signature-evaluator/tests/BUILD
@@ -1,6 +1,1 @@
-python_tests(skip_bandit=True, skip_mypy=True, dependencies=[":expected_signers_yamls"])
-
-files(
-    name="expected_signers_yamls",
-    sources=["fixtures/**"],
-)
+python_tests(skip_bandit=True, skip_mypy=True)

--- a/yaku-apps-python/apps/sharepoint-fetcher/src/yaku/sharepoint_fetcher/cloud/connect.py
+++ b/yaku-apps-python/apps/sharepoint-fetcher/src/yaku/sharepoint_fetcher/cloud/connect.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Tuple
 from urllib.parse import quote, urlparse
 
 import requests
-from requests.exceptions import HTTPError
 from yaku.autopilot_utils.errors import (
     AutopilotConfigurationError,
     AutopilotError,
@@ -51,24 +50,17 @@ class Connect:
         It requires the credential for the App Registration in Azure ( the client id,
         the tenant id and the client secret ).
         """
-        try:
-            token_api = f"https://login.microsoftonline.com/{tenant_id}/oauth2/token"
-            payload = f"grant_type={GRANT_TYPE}&client_id={client_id}&client_secret={client_secret}&resource={RESOURCE}"
-            access_token_response = requests.request(
-                "POST", token_api, data=payload, verify=True
-            )
-            access_token_response.raise_for_status()
-            response_data = access_token_response.json()
-            access_token = response_data["access_token"]
+        token_api = f"https://login.microsoftonline.com/{tenant_id}/oauth2/token"
+        payload = f"grant_type={GRANT_TYPE}&client_id={client_id}&client_secret={client_secret}&resource={RESOURCE}"
+        access_token_response = requests.request("POST", token_api, data=payload, verify=True)
+        access_token_response.raise_for_status()
+        response_data = access_token_response.json()
+        access_token = response_data["access_token"]
 
-            headers = {
-                "Authorization": f"Bearer {access_token}",
-            }
-            return headers
-        except HTTPError as http_err:
-            print(f"HTTP error occured: {http_err}")
-        except Exception as err:
-            print(f"Error occurred: {err}")
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+        }
+        return headers
 
     def _exchange_url_by_domain_and_site_name(self, sharepoint_site: str) -> Tuple[str, str]:
         """

--- a/yaku-apps-python/apps/sharepoint-fetcher/tests/test_connect_cloud.py
+++ b/yaku-apps-python/apps/sharepoint-fetcher/tests/test_connect_cloud.py
@@ -9,7 +9,10 @@ from yaku.sharepoint_fetcher.cloud.connect import Connect
 
 
 @pytest.fixture
-def connect():
+@patch("yaku.sharepoint_fetcher.cloud.connect.Connect._sharepoint_cloud_instance_connect")
+def connect(mock_connect):
+    mock_connect.return_value = {"Authorization": "Bearer your_token"}
+
     connect = Connect(
         "https://some.sharepoint.server/sites/123456/",
         "tenant-id",
@@ -19,15 +22,23 @@ def connect():
     return connect
 
 
-def test_initial_value():
+@patch("yaku.sharepoint_fetcher.cloud.connect.Connect._sharepoint_cloud_instance_connect")
+def test_initial_value(mock_connect):
+    mock_connect.return_value = {"Authorization": "Bearer your_token"}
+
     url = "https://sharepoint.com"
     connect = Connect(url, "tenant-id", "client-id", "client-secret")
+
     assert connect._sharepoint_site == url
 
 
-def test_missing_trailing_slash_in_url():
+@patch("yaku.sharepoint_fetcher.cloud.connect.Connect._sharepoint_cloud_instance_connect")
+def test_missing_trailing_slash_in_url(mock_connect):
+    mock_connect.return_value = {"Authorization": "Bearer your_token"}
+
     url = "https://sharepoint.com/"
     connect = Connect(url, "tenant-id", "client-id", "client-secret")
+
     assert connect._sharepoint_site == url[:-1]
 
 

--- a/yaku-apps-python/apps/sharepoint-fetcher/tests/test_sharepoint_factory.py
+++ b/yaku-apps-python/apps/sharepoint-fetcher/tests/test_sharepoint_factory.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import patch
 from yaku.sharepoint_fetcher.config import Settings
 from yaku.sharepoint_fetcher.sharepoint_factory import SharePointFetcherFactory
 
@@ -31,10 +32,14 @@ def test_create_on_premise_sharepoint(settings):
     assert on_premise_sharepoint is not None
 
 
-def test_create_cloud_sharepoint(settings):
+@patch("yaku.sharepoint_fetcher.cloud.connect.Connect._sharepoint_cloud_instance_connect")
+def test_create_cloud_sharepoint(mock_connect, settings):
+    mock_connect.return_value = {"Authorization": "Bearer your_token"}
+
     settings.is_cloud = True
     list_title_property_map = []
     cloud_sharepoint = SharePointFetcherFactory.selectSharepointInstance(
         settings, list_title_property_map, filter_config_file_data
     )
+
     assert cloud_sharepoint is not None

--- a/yaku-apps-python/apps/sharepoint-fetcher/tests/test_sharepoint_fetcher_cloud.py
+++ b/yaku-apps-python/apps/sharepoint-fetcher/tests/test_sharepoint_fetcher_cloud.py
@@ -13,6 +13,15 @@ from yaku.sharepoint_fetcher.cloud.sharepoint_fetcher_cloud import (
 from yaku.sharepoint_fetcher.selectors import FilesSelectors, Selector
 
 
+@pytest.fixture(scope="function", autouse=True)
+def mock_connect(mocker):
+    mocked_headers = {"Authorization": "Bearer your_token"}
+    mocked_connect = mocker.patch(
+        "yaku.sharepoint_fetcher.cloud.connect.Connect._sharepoint_cloud_instance_connect"
+    )
+    mocked_connect.return_value = mocked_headers
+
+
 @pytest.fixture
 def default_fetcher():
     return SharepointFetcherCloud(


### PR DESCRIPTION
This PR removes the try/except part of `yaku-apps-python/apps/sharepoint-fetcher/src/yaku/sharepoint_fetcher/cloud/connect.py` so that errors during getting the session token are reported as an exception and not just as a (more or less) silent printout on the console.

I had to updated a few test files as they were exactly using this behavior to just ignore the connect error.