### PR TITLE
fix: Avoid using empty object as type

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,7 @@
     "rules": {
       "complexity": {
         "noBannedTypes": {
-          "level": "off"
+          "level": "error"
         },
         "noForEach": {
           "level": "off"

--- a/qg-api-service/qg-api-service/src/namespace/metrics/utils/interfaces/core.interface.ts
+++ b/qg-api-service/qg-api-service/src/namespace/metrics/utils/interfaces/core.interface.ts
@@ -2,5 +2,4 @@
 //
 // SPDX-License-Identifier: MIT
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export type Core = {}
+export type Core = Record<string, any>

--- a/qg-api-service/qg-api-service/src/namespace/metrics/utils/interfaces/core.interface.ts
+++ b/qg-api-service/qg-api-service/src/namespace/metrics/utils/interfaces/core.interface.ts
@@ -2,4 +2,4 @@
 //
 // SPDX-License-Identifier: MIT
 
-export type Core = Record<string, any>
+export type Core = object


### PR DESCRIPTION
One of the biome warnings was that `{}` should not be used as type. I replaced it by `Record<string, any>`, hope this is correct.