### PR TITLE
fix: Don't use 'this' in static methods

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,7 @@
           "level": "off"
         },
         "noThisInStatic": {
-          "level": "off"
+          "level": "error"
         },
         "noUselessCatch": {
           "level": "off"

--- a/qg-api-service/qg-api-service/src/user/long-running-token/long.running.token.ts
+++ b/qg-api-service/qg-api-service/src/user/long-running-token/long.running.token.ts
@@ -137,8 +137,8 @@ export class LongRunningToken {
   }
 
   static generatePreToken(): PreToken {
-    const random = randomBytes(this.RAND_LEN)
-    return new InnerPreToken(random, this.SALT_ROUNDS)
+    const random = randomBytes(LongRunningToken.RAND_LEN)
+    return new InnerPreToken(random, LongRunningToken.SALT_ROUNDS)
   }
 
   static from(id: number, preToken: PreToken): LongRunningToken {
@@ -150,9 +150,9 @@ export class LongRunningToken {
       throw new Error('Illegal id, expected to be an integer')
     }
 
-    if (id < this.MIN_SERIAL || id > this.MAX_SERIAL) {
+    if (id < LongRunningToken.MIN_SERIAL || id > LongRunningToken.MAX_SERIAL) {
       throw new Error(
-        `Illegal token, expected id to be number between ${this.MIN_SERIAL} and ${this.MAX_SERIAL}`,
+        `Illegal token, expected id to be number between ${LongRunningToken.MIN_SERIAL} and ${LongRunningToken.MAX_SERIAL}`,
       )
     }
 

--- a/qg-api-service/yaku-client-lib/src/client-config.ts
+++ b/qg-api-service/yaku-client-lib/src/client-config.ts
@@ -8,13 +8,13 @@ export default class ClientConfig {
   static config: YakuClientConfig
 
   public static getConfig(): YakuClientConfig | null {
-    if (!this.config) {
+    if (!ClientConfig.config) {
       return null
     }
-    return this.config
+    return ClientConfig.config
   }
 
   public static setConfig(config: YakuClientConfig): void {
-    this.config = config
+    ClientConfig.config = config
   }
 }


### PR DESCRIPTION
There were some usages of `this` in static methods, where there is no object instance, but only the class itself. This PR corrects it by replacing `this` with the class name.