### PR TITLE
fix: Don't use empty catch phrases which just rethrow

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -37,7 +37,7 @@
           "level": "error"
         },
         "noUselessCatch": {
-          "level": "off"
+          "level": "error"
         },
         "noUselessConstructor": {
           "level": "off"

--- a/qg-api-service/yaku-client-lib/src/api-calls.ts
+++ b/qg-api-service/yaku-client-lib/src/api-calls.ts
@@ -14,21 +14,17 @@ export async function createResource<T>(
   body: any,
   token: string,
 ): Promise<T> {
-  try {
-    const response: Response = await executeRestCall(url, {
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    })
+  const response: Response = await executeRestCall(url, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  })
 
-    const data = (await response.json()) as T
-    return data
-  } catch (err) {
-    throw err
-  }
+  const data = (await response.json()) as T
+  return data
 }
 
 export async function uploadData(
@@ -75,17 +71,13 @@ export async function transformData(
 }
 
 export async function getResource<T>(url: string, token: string): Promise<T> {
-  try {
-    const response: Response = await executeRestCall(url, {
-      method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
-    })
+  const response: Response = await executeRestCall(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  })
 
-    const data = (await response.json()) as T
-    return data
-  } catch (err) {
-    throw err
-  }
+  const data = (await response.json()) as T
+  return data
 }
 
 export async function listAllResources<T>(
@@ -95,20 +87,16 @@ export async function listAllResources<T>(
   let next = url
   const items: T[] = []
   while (next !== undefined) {
-    try {
-      const response: Response = await executeRestCall(next, {
-        method: 'GET',
-        headers: { Authorization: `Bearer ${token}` },
-      })
+    const response: Response = await executeRestCall(next, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    })
 
-      const raw = await response.json()
+    const raw = await response.json()
 
-      next = raw?.links?.next
+    next = raw?.links?.next
 
-      items.push(...raw.data)
-    } catch (err) {
-      throw err
-    }
+    items.push(...raw.data)
   }
 
   return items


### PR DESCRIPTION
This PR activates the rule `noUselessCatch` which triggers on catch phrases which simply rethrow the exception and hence are _useless_.