### PR TITLE
fix: Avoid symlinks for user-docs venv creation

### DIFF
--- a/.github/workflows/build-user-documentation.yml
+++ b/.github/workflows/build-user-documentation.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ SPDX-License-Identifier: MIT
 -->
 
 # Yaku
+
 [![Build](https://github.com/B-S-F/yaku/actions/workflows/build.yml/badge.svg)](https://github.com/B-S-F/yaku/actions/workflows/build.yml)
+[![User Documentation](https://github.com/B-S-F/yaku/actions/workflows/publish-user-docs-to-gh-pages.yml/badge.svg)](https://b-s-f.github.io/yaku/)
 
 !! THIS PROJECT IS UNDER CONSTRUCTION !!
 
@@ -15,7 +17,9 @@ Foto from Mabel Amber from <a href="https://www.pexels.com/de-de/foto/nahaufnahm
 </figcaption>
 
 ## Development
+
 Developer docu for the project see [DEVELOPMENT.md](./DEVELOPMENT.md).
 
 ## Licenses
+
 See [LICENSES](./LICENSES) folder for the project's licenses.

--- a/user-documentation/Makefile
+++ b/user-documentation/Makefile
@@ -57,7 +57,14 @@ requirements.lock: requirements.txt
 .PHONY: make-virtualenv
 make-virtualenv:
 	rm -rf .venv
-	if compgen uv; then uv venv --python 3.12; else python3.12 -m venv .venv; fi
+	python3.12 -m venv --copies .venv
+	# uv does not work for CI, see https://github.com/astral-sh/uv/issues/6782
+	# as it creates symlinks to system Python which are not cached properly
+	#if compgen uv; then \
+		uv venv --link-mode hardlink --python 3.12; \
+	else \
+		python3.12 -m venv --copies .venv; \
+	fi
 
 .PHONY: checklinks
 checklinks:

--- a/user-documentation/requirements.lock
+++ b/user-documentation/requirements.lock
@@ -50,7 +50,7 @@ sphinxcontrib-mermaid==1.0.0
 sphinxcontrib-openapi==0.8.4
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
-starlette==0.41.2
+starlette==0.41.3
 typing-extensions==4.12.2
 uc-micro-py==1.0.3
 urllib3==2.2.3


### PR DESCRIPTION
There was/is an issue with the creation and caching of the Python virtual environment.

When we create it with `uv` or `python3 -m venv`, the `python` executable is only linked to the system's Python installation.

This symlink is not properly cached in the GitHub cache action.

The workaround is to use the `--copies` flag for `venv`, however there is no equivalent flag for `uv`, although there is a similar one for linking cached Python libraries (`--link-mode`).

Unless https://github.com/astral-sh/uv/issues/6782 is fixed soon, we have to live with the workaround of using good old `venv`.

P.S.: the build still fails for this PR as we are using `pull_request_target`.