### PR TITLE
chore: Add VSCode linter integration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "streetsidesoftware.code-spell-checker",
-    "davidanson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint",
+    "biomejs.biome"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,8 @@
     "workitem",
     "workitems",
     "yaku"
-  ]
+  ],
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }


### PR DESCRIPTION
This adds `biome.js` as the default `js/ts` formatter in VSCode to help catch formatting issues before trying to commit changes.