### PR TITLE
fix: Python apps printed extraneous log messages on --version command

### DIFF
--- a/yaku-apps-python/packages/autopilot-utils/tests/app_single_command/tests-pex/test_common_flags.py
+++ b/yaku-apps-python/packages/autopilot-utils/tests/app_single_command/tests-pex/test_common_flags.py
@@ -14,6 +14,7 @@ def test_pex_version_flag():
             "--version",
         ],
         encoding="utf-8",
+        stderr=subprocess.STDOUT,
     )
 
     assert output.strip() == file_version.strip()
@@ -26,6 +27,7 @@ def test_pex_help_flag():
             "--help",
         ],
         encoding="utf-8",
+        stderr=subprocess.STDOUT,
     )
 
     assert output.strip().startswith("Usage: ")


### PR DESCRIPTION
This PR fixes an issue with Python apps using `autopilot_utils`.

When running `app --version`, they apps printed out not just the version number, but also some debug log messages, e.g.

```
2024-11-28 10:13:28.239 | DEBUG    | yaku.autopilot_utils.cli_base:wrapped_function:167 - Reading version from file '_version.txt' in package 'yaku.app_single_command'
2024-11-28 10:13:28.241 | DEBUG    | yaku.autopilot_utils.cli_base:wrapped_function:173 - Version is: 0.1.0

0.1.0
```

I fixed it by checking the debug flag and setting up logging before calling the version retrieval callback function.