### PR TITLE
docs: Remove copyright from sample config files as it breaks line numbers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: reuse-lint-file
         files: '\.(adb|adoc|ads|aes|ahk|ahkl|aidl|applescript|arb|asax|asc|asciidoc|ashx|asm|asmx|aspx|aux|awk|axd|bash|bat|bats|bb|bbappend|bbclass|bib|bzl|c|cabal|cc|cjs|cl|clj|cljc|cljs|cls|cmake|code-workspace|coffee|cpp|cs|csl|cson|css|csproj|csv|cu|cuh|cxx|d|dart|di|doc|docx|dotx|dts|dtsi|el|erl|ex|exs|f|fsproj|f03|f08|f90|f95|fish|fnl|fodp|fods|fodt|for|ftn|fpp|fs|fsx|ftl|gemspec|go|gradle|graphql|graphqls|gqls|groovy|h|ha|hbs|hcl|hh|hjson|hpp|hrl|hs|html|hx|hxsl|ini|ino|ipynb|iuml|j2|java|jinja|jinja2|jl|jpg|jpeg|js|json|json5|jsonc|jsp|jsx|jy|ksh|kt|kts|l|latex|ld|less|license|lisp|lsp|lua|m|m4|man|markdown|md|mjs|mk|ml|mli|nim.cfg|nim|nimble|nimrod|nix|odb|odf|odg|odm|odp|ods|odt|org|otp|ots|ott|pdf|pem|php|php3|php4|php5|pl|plantuml|png|po|pod|pot|ppt|pptx|pri|pro|props|properties|proto|ps1|psm1|pu|puml|pxd|py|pyi|pyw|pyx|qbs|qml|qrc|qss|R|rake|rb|rbw|rbx|rkt|Rmd|rs|rss|rst|s|sass|sbt|sc|scad|scala|scm|scpt|scptd|scss|scsyndef|sh|sld|sln|sls|sml|soy|sps|sql|sty|svg|svelte|swift|t|tcl|tex|textile|tf|tfvars|thy|toc|toml|ts|tsx|ttl|typ|ui|v|vala|vbproj|vhdl|vim|vm|vsh|vtl|vue|webp|xls|xlsx|xml|xq|xql|xqm|xqy|xquery|xsd|xsh|xsl|yaml|yml|zig|zsh)$|Dockerfile|Makefile|CMakeLists\.txt|Gemfile|Jenkinsfile|Rakefile|requirements\.txt'
-        exclude: 'documentation/under-construction\.jpg|user-documentation/source/resources/features/image-source-information\.md|user-documentation/source/onboarding\.md'
+        exclude: 'documentation/under-construction\.jpg|user-documentation/source/resources/features/image-source-information\.md|user-documentation/source/onboarding\.md|user-documentation/source/.*.yaml'
 
   ####
   ## User documentation

--- a/user-documentation/source/autopilots/ado/how-to/resources/children/ado-fetcher-evaluator-config.yaml
+++ b/user-documentation/source/autopilots/ado/how-to/resources/children/ado-fetcher-evaluator-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: "SELECT [System.Id], [System.State] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] == 'Epic'"
   neededFields:

--- a/user-documentation/source/autopilots/ado/how-to/resources/children/qg-config.yaml
+++ b/user-documentation/source/autopilots/ado/how-to/resources/children/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/ado-fetcher-evaluator-config-1.yaml
+++ b/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/ado-fetcher-evaluator-config-1.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: "SELECT [System.Id], [System.State] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] = 'Epic' AND ([System.State] = 'To Do' OR [System.State] = 'Doing') AND ([Microsoft.VSTS.Common.Priority] = 1 OR [Microsoft.VSTS.Common.Priority] = 2)"
   neededFields:

--- a/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/ado-fetcher-evaluator-config-2.yaml
+++ b/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/ado-fetcher-evaluator-config-2.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: "SELECT [System.Id], [System.State] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] = 'Epic' AND ([System.State] = 'To Do' OR [System.State] = 'Doing') AND ([Microsoft.VSTS.Common.Priority] = 3 OR [Microsoft.VSTS.Common.Priority] = 4)"
   neededFields:

--- a/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/qg-config.yaml
+++ b/user-documentation/source/autopilots/ado/how-to/resources/or-conditions/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/ado/reference/resources/evaluator-config.yaml
+++ b/user-documentation/source/autopilots/ado/reference/resources/evaluator-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: "<wiql-query>" # used by the fetcher
   neededFields:

--- a/user-documentation/source/autopilots/ado/reference/resources/fetcher-config.yaml
+++ b/user-documentation/source/autopilots/ado/reference/resources/fetcher-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: 'wiql query' # A WiQL query
   neededFields: # List of work item fields to fetch. Default fields are: State and Title

--- a/user-documentation/source/autopilots/ado/tutorials/resources/ado-fetcher-evaluator-config.yaml
+++ b/user-documentation/source/autopilots/ado/tutorials/resources/ado-fetcher-evaluator-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 workItems:
   query: "SELECT [System.Id], [System.State] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] = 'Epic' AND ([System.State] = 'To Do' OR [System.State] = 'Doing') AND ([Microsoft.VSTS.Common.Priority] = 1 OR [Microsoft.VSTS.Common.Priority] = 2)"
   neededFields:

--- a/user-documentation/source/autopilots/ado/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/ado/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/artifactory/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/artifactory/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/defender-for-cloud/reference/resources/qg-config-alerts.yaml
+++ b/user-documentation/source/autopilots/defender-for-cloud/reference/resources/qg-config-alerts.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/defender-for-cloud/reference/resources/qg-config-recommendations.yaml
+++ b/user-documentation/source/autopilots/defender-for-cloud/reference/resources/qg-config-recommendations.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/defender-for-cloud/tutorials/resources/qg-config-alerts.yaml
+++ b/user-documentation/source/autopilots/defender-for-cloud/tutorials/resources/qg-config-alerts.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/defender-for-cloud/tutorials/resources/qg-config-recommendations.yaml
+++ b/user-documentation/source/autopilots/defender-for-cloud/tutorials/resources/qg-config-recommendations.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/configFile.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/configFile.yaml
@@ -1,5 +1,1 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 pageId: '13121989'

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-diff-basic.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-diff-basic.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-diff-threshold.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-diff-threshold.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-cli.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-cli.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-config-file.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-config-file.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-env.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-source-env.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-timeout.yaml
+++ b/user-documentation/source/autopilots/docupedia/how-to/resources/qg-config-timeout.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/docupedia/reference/resources/docupedia-fetcher-config-file.yaml
+++ b/user-documentation/source/autopilots/docupedia/reference/resources/docupedia-fetcher-config-file.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 exporterId: 'myExporterId'
 exportSchemeId: 'myExportSchemeId'
 outputName: 'myOutputName'

--- a/user-documentation/source/autopilots/docupedia/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/docupedia/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/git/reference/resources/git-fetcher-config.yaml
+++ b/user-documentation/source/autopilots/git/reference/resources/git-fetcher-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 org: github-org    # Organization name
 repo: github-repo  # Repo name
 resource: pull-requests  # Resource to fetch. One of: pull-requests, branches, tags (branches and tags are only supported for Bitbucket)

--- a/user-documentation/source/autopilots/git/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/git/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/git/tutorials/resources/gh-cli-qg-config.yaml
+++ b/user-documentation/source/autopilots/git/tutorials/resources/gh-cli-qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/git/tutorials/resources/git-fetcher-config.yaml
+++ b/user-documentation/source/autopilots/git/tutorials/resources/git-fetcher-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 org: your-github-org
 repo: your-repository
 resource: prs

--- a/user-documentation/source/autopilots/git/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/git/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/ilm/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/ilm/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/ilm/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/ilm/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/jira/reference/resources/jira-config-structure.yaml
+++ b/user-documentation/source/autopilots/jira/reference/resources/jira-config-structure.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 query: '<jql-query>'  # A jql query
 neededFields: # List of issue fields to fetch.
   - field1

--- a/user-documentation/source/autopilots/jira/reference/resources/jira-config-with-and.yaml
+++ b/user-documentation/source/autopilots/jira/reference/resources/jira-config-with-and.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 query: "project = PROJECT1 and issuetype in ('Task')"
 neededFields:
   - "summary"

--- a/user-documentation/source/autopilots/jira/reference/resources/jira-config.yaml
+++ b/user-documentation/source/autopilots/jira/reference/resources/jira-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 query: "project = PROJECT1 and issuetype in ('Task')"
 neededFields:
   - "summary"

--- a/user-documentation/source/autopilots/jira/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/jira/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/json/reference/resources/example-config.yaml
+++ b/user-documentation/source/autopilots/json/reference/resources/example-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 checks:
   - name: has_category_check # Name of the check (can be any name the user wants)
     ref: $.store.book[*] # Reference to the object inside the json file (line 3 in the example json file below)

--- a/user-documentation/source/autopilots/json/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/json/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/json/tutorials/resources/json-evaluator-config.yaml
+++ b/user-documentation/source/autopilots/json/tutorials/resources/json-evaluator-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 checks:
   - name: has_good_coverage
     ref: $.totals.percent_covered

--- a/user-documentation/source/autopilots/json/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/json/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/manual-answer/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/manual-answer/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/mend/tutorials/resources/qg-config-alerts.yaml
+++ b/user-documentation/source/autopilots/mend/tutorials/resources/qg-config-alerts.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/mend/tutorials/resources/qg-config-vulns.yaml
+++ b/user-documentation/source/autopilots/mend/tutorials/resources/qg-config-vulns.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/pdf-signature/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/pdf-signature/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/sharepoint/reference/resources/evaluator-config.yaml
+++ b/user-documentation/source/autopilots/sharepoint/reference/resources/evaluator-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 - file: 'Folder/Document.docx'
         # ↑ Glob pattern for the file to be checked with the following rules
   rules:

--- a/user-documentation/source/autopilots/sharepoint/reference/resources/fetcher-config.yaml
+++ b/user-documentation/source/autopilots/sharepoint/reference/resources/fetcher-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 destination_path: <SomePath>
 is_cloud: True / False
 project_path: <SomeProjectPath>

--- a/user-documentation/source/autopilots/sharepoint/reference/resources/fetcher-filter-config.yaml
+++ b/user-documentation/source/autopilots/sharepoint/reference/resources/fetcher-filter-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 - files: 'OneDriving_Q-Activity-List.xlsx(1)/*' # ← first comes a `files` section with a wildcard
   title: 'File link title' # ← needed if you want a message with the link of the selected file
   select: # ← list of property checks, similar to Sharepoint evaluator

--- a/user-documentation/source/autopilots/sharepoint/tutorials/resources/qg-config-cloud.yaml
+++ b/user-documentation/source/autopilots/sharepoint/tutorials/resources/qg-config-cloud.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/sharepoint/tutorials/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/sharepoint/tutorials/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/sharepoint/tutorials/resources/sharepoint-evaluator-config-file-cloud.yaml
+++ b/user-documentation/source/autopilots/sharepoint/tutorials/resources/sharepoint-evaluator-config-file-cloud.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 - file: 'Instruction_Publishing_Service_Spec Sheets_20120926_en.doc'
   rules:
     - property: 'lastModifiedDateTime'

--- a/user-documentation/source/autopilots/sharepoint/tutorials/resources/sharepoint-evaluator-config-file.yaml
+++ b/user-documentation/source/autopilots/sharepoint/tutorials/resources/sharepoint-evaluator-config-file.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 - file: 'Instruction_Publishing_Service_Spec Sheets_20120926_en.doc'
   rules:
     - property: 'Modified'

--- a/user-documentation/source/autopilots/sonarqube/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/sonarqube/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/autopilots/splunk/reference/resources/qg-config.yaml
+++ b/user-documentation/source/autopilots/splunk/reference/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/finalizers/html/resources/html-finalizer-config.yaml
+++ b/user-documentation/source/finalizers/html/resources/html-finalizer-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 finalize:
   run: |
     html-finalizer

--- a/user-documentation/source/finalizers/jira/resources/jira-finalizer-config.yaml
+++ b/user-documentation/source/finalizers/jira/resources/jira-finalizer-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 requirements:
   '1.15': # requirement ids from qg-config
     issues: # A list of mapped issues that should be updated with the content of the requirement result.

--- a/user-documentation/source/finalizers/jira/resources/jira-finalizer-run-env.yaml
+++ b/user-documentation/source/finalizers/jira/resources/jira-finalizer-run-env.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 finalize:
   run: |
     jira-finalizer update-issues

--- a/user-documentation/source/finalizers/jira/resources/qg-config.yaml
+++ b/user-documentation/source/finalizers/jira/resources/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/finalizers/sharepoint/how-to/resources/qg-config-upload-files.yaml
+++ b/user-documentation/source/finalizers/sharepoint/how-to/resources/qg-config-upload-files.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/finalizers/sharepoint/how-to/resources/qg-config-upload-folder-finalize.yaml
+++ b/user-documentation/source/finalizers/sharepoint/how-to/resources/qg-config-upload-folder-finalize.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/resources/quickstart/qg-config.yaml
+++ b/user-documentation/source/resources/quickstart/qg-config.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 metadata:
   version: v1
 header:

--- a/user-documentation/source/resources/quickstart/sharepoint-evaluator-config-file.yaml
+++ b/user-documentation/source/resources/quickstart/sharepoint-evaluator-config-file.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024 grow platform GmbH
-#
-# SPDX-License-Identifier: MIT
-
 - file: 'example-document.txt'
   rules:
     - property: 'Modified'


### PR DESCRIPTION
In the documentation, we often refer to line numbers in config files. By adding the copyright header to all YAML config files, these line references got messed up.

I don't think that we need the copyright header in these files, hence I removed it.