### PR TITLE
ci: allow usage of cache from main branch in PR

### DIFF
--- a/.github/workflows/build-backend-docker-image.yml
+++ b/.github/workflows/build-backend-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: qg-api-service
-          key: qg-api-service-${{ github.ref }}-${{ hashFiles('qg-api-service/**') }}
+          key: qg-api-service-${{ hashFiles('qg-api-service/**') }}
 
       - name: Log in to the Container Registry
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: qg-api-service
-          key: qg-api-service-${{ github.ref }}-${{ hashFiles('qg-api-service/**') }}
+          key: qg-api-service-${{ hashFiles('qg-api-service/**') }}
           lookup-only: true
 
       - name: Setup Node.js

--- a/.github/workflows/build-core-docker-image.yml
+++ b/.github/workflows/build-core-docker-image.yml
@@ -17,19 +17,19 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: onyx/bin
-          key: onyx-${{ github.ref }}-${{ hashFiles('onyx/**') }}
+          key: onyx-${{ hashFiles('onyx/**') }}
 
       - name: Restore TypeScript Apps Cache
         uses: actions/cache/restore@v4
         with:
           path: yaku-apps-typescript
-          key: typescript-apps-${{ github.ref }}-${{ hashFiles('yaku-apps-typescript/**') }}
+          key: typescript-apps-${{ hashFiles('yaku-apps-typescript/**') }}
 
       - name: Restore Python Apps Cache
         uses: actions/cache/restore@v4
         with:
           path: yaku-apps-python/dist
-          key: python-apps-${{ github.ref }}-${{ hashFiles('yaku-apps-python/**') }}
+          key: python-apps-${{ hashFiles('yaku-apps-python/**') }}
 
       - name: Log in to the Container Registry
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/build-onyx.yml
+++ b/.github/workflows/build-onyx.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: onyx/bin
-          key: onyx-${{ github.ref }}-${{ hashFiles('onyx/**') }}
+          key: onyx-${{ hashFiles('onyx/**') }}
           lookup-only: true
 
       - name: Setup Go

--- a/.github/workflows/build-python-apps.yml
+++ b/.github/workflows/build-python-apps.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PYTHON_APPS_FOLDER }}/dist
-          key: python-apps-${{ github.ref }}-${{ hashFiles('yaku-apps-python/**') }}
+          key: python-apps-${{ hashFiles('yaku-apps-python/**') }}
           lookup-only: true
 
       - name: Put all files from ${{ env.PYTHON_APPS_FOLDER }} in cwd

--- a/.github/workflows/build-typescript-apps.yml
+++ b/.github/workflows/build-typescript-apps.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: yaku-apps-typescript
-          key: typescript-apps-${{ github.ref }}-${{ hashFiles('yaku-apps-typescript/**') }}
+          key: typescript-apps-${{ hashFiles('yaku-apps-typescript/**') }}
           lookup-only: true
 
       - name: Setup Node.js

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: yaku-ui
-          key: yaku-ui-${{ github.ref }}-${{ hashFiles('yaku-ui/**') }}
+          key: yaku-ui-${{ hashFiles('yaku-ui/**') }}
           lookup-only: true
 
       - name: Setup Node.js


### PR DESCRIPTION
Change cache strategy making used of the cache created on the build of the main branch.

See github docu on caching:

*[Matching a cache key](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key)
The cache action first searches for cache hits for key and the cache version in the branch containing the workflow run. If there is no hit, it searches for restore-keys and the version. If there are still no hits in the current branch, the cache action retries same steps on the default branch. Please note that the scope restrictions apply during the search. For more information, see [Restrictions for accessing a cache](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache).

Cache version is a way to stamp a cache with metadata of the path and the compression tool used while creating the cache. This ensures that the consuming workflow run uniquely matches a cache it can actually decompress and use. For more information, see [Cache Version](https://github.com/actions/cache#cache-version) in the Actions Cache documentation.*